### PR TITLE
[fix] Fix stereo shape issue by converting to mono

### DIFF
--- a/frechet_audio_distance/fad.py
+++ b/frechet_audio_distance/fad.py
@@ -24,6 +24,10 @@ def load_audio_task(fname):
     assert wav_data.dtype == np.int16, 'Bad sample type: %r' % wav_data.dtype
     wav_data = wav_data / 32768.0  # Convert to [-1.0, +1.0]
 
+    # Convert to mono
+    if len(wav_data.shape) > 1:
+        wav_data = np.mean(wav_data, axis=1)
+
     if sr != SAMPLE_RATE:
         wav_data = resampy.resample(wav_data, sr, SAMPLE_RATE)
 


### PR DESCRIPTION
Solves https://github.com/gudgud96/frechet-audio-distance/issues/1. 

After inspecting [torchvggish code](https://github.com/harritaylor/torchvggish/blob/master/torchvggish/vggish_input.py#L30), converting to mono will be a better solution.