### PR TITLE
Support float32 PCM wav files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Hao Hao Tan
+Copyright (c) 2023 Hao Hao Tan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -20,14 +20,16 @@ frechet = FrechetAudioDistance(
     model_name="vggish",
     use_pca=False, 
     use_activation=False,
-    verbose=False
+    verbose=False,
+    dtype="float32"
 )
 # to use `PANN`
 frechet = FrechetAudioDistance(
     model_name="pann",
     use_pca=False, 
     use_activation=False,
-    verbose=False
+    verbose=False,
+    dtype="float32"
 )
 fad_score = frechet.score("/path/to/background/set", "/path/to/eval/set")
 
@@ -49,6 +51,11 @@ FAD scores comparison w.r.t. to original implementation in `google-research/frec
 |                              |   baseline vs test1   |     baseline vs test2    |
 |:----------------------------:|:---------------------:|:------------------------:|
 |    `frechet_audio_distance`  |        0.000465       |          0.00008594      |
+
+### To contribute
+
+- Run `python3 -m build` to build your version locally. The built wheel should be in `dist/`.
+- `pip install` your local wheel version, and run `pytest test/` to validate your changes.
 
 ### References
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "frechet_audio_distance"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
   { name="Hao Hao Tan", email="helloharry66@gmail.com" },
 ]
@@ -24,6 +24,7 @@ dependencies = [
   'tqdm',
   'soundfile',
   'resampy',
+  'torchlibrosa'
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ scipy
 tqdm
 soundfile
 resampy
+torchlibrosa


### PR DESCRIPTION
Support audio load for `float32` PCM wav files as per https://github.com/gudgud96/frechet-audio-distance/issues/11.

`dtype` is a passable parameter to the `score` function. Examples updated on README.