### PR TITLE
add embeddings reusability in score fct + update readme accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,23 @@ fad_score = frechet.score("/path/to/background/set", "/path/to/eval/set", dtype=
 
 ```
 
+When computing the Frechet Audio Distance, you can choose to save the embeddings for future use. This capability not only ensures consistency across evaluations but can also significantly reduce computation time, especially if you're evaluating multiple times using the same dataset.
+
+```python
+# Specify the paths to your saved embeddings
+background_embds_path = "/path/to/saved/background/embeddings.npy"
+eval_embds_path = "/path/to/saved/eval/embeddings.npy"
+
+# Compute FAD score while reusing the saved embeddings (or saving new ones if paths are provided and embeddings don't exist yet)
+fad_score = frechet.score(
+    "/path/to/background/set",
+    "/path/to/eval/set",
+    background_embds_path=background_embds_path,
+    eval_embds_path=eval_embds_path,
+    dtype="float32"
+)
+```
+
 ### Result validation
 
 **Test 1: Distorted sine waves on vggish** (as provided [here](https://github.com/google-research/google-research/blob/master/frechet_audio_distance/gen_test_files.py#L86)) [[notes](https://jexrj22lgy.larksuite.com/docx/Vat2dr8Aqonim6xmE6nuoBVZsUe)]


### PR DESCRIPTION
This is an improvement suggestion related to #13
This code update allows to easily reuse the embeddings. 
The code is not 100% backward compatible as it does not use the `store_embds` anymore, but I made it such that people who were using the default value for `store_embds` won't see any difference.
I also updated the demo in the README to show how to use this update.