### PR TITLE
fix fad calculation for newer versions of scipy

### DIFF
--- a/frechet_audio_distance/fad.py
+++ b/frechet_audio_distance/fad.py
@@ -327,13 +327,13 @@ class FrechetAudioDistance:
         diff = mu1 - mu2
 
         # Product might be almost singular
-        covmean, _ = linalg.sqrtm(sigma1.dot(sigma2), disp=False)
+        covmean, _ = linalg.sqrtm(sigma1.dot(sigma2).astype(complex), disp=False)
         if not np.isfinite(covmean).all():
             msg = ('fid calculation produces singular product; '
                    'adding %s to diagonal of cov estimates') % eps
             print(msg)
             offset = np.eye(sigma1.shape[0]) * eps
-            covmean = linalg.sqrtm((sigma1 + offset).dot(sigma2 + offset))
+            covmean = linalg.sqrtm((sigma1 + offset).dot(sigma2 + offset).astype(complex))
 
         # Numerical error might give slight imaginary component
         if np.iscomplexobj(covmean):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-numpy==1.23.4
+numpy
 torch
-scipy==1.10.1
+scipy
 tqdm
 soundfile
 resampy


### PR DESCRIPTION
fixes fad calculation and unpins numpy and scipy dependencies

#19 pinned the numpy and scipy dependencies to fix an imaginary component error. The reason for this error is a change in scipy's `linalg.sqrtm` function. We can avoid this altogether by first converting the input to complex before calling sqrtm

tested these changes with the following script: 

```
np.random.seed(42)

SAMPLE_RATE = 16000

frechet = FrechetAudioDistance(
    ckpt_dir="/home/ubuntu/cache/metrics/checkpoints",
    model_name="vggish",
    # submodel_name="630k-audioset", # for CLAP only
    sample_rate=SAMPLE_RATE,
    use_pca=False, # for VGGish only
    use_activation=False, # for VGGish only
    verbose=True,
    audio_load_worker=8,
    # enable_fusion=False, # for CLAP only
)

for traget, count, param in [("background", 10, None), ("test1", 5, 0.0001), ("test2", 5, 0.00001)]:
    os.makedirs(traget, exist_ok=True)
    frequencies = np.linspace(100, 1000, count).tolist()
    for freq in frequencies:
        samples = gen_sine_wave(freq, param=param)
        filename = os.path.join(traget, "sin_%.0f.wav" % freq)
        print("Creating: %s with %i samples." % (filename, samples.shape[0]))
        sf.write(filename, samples, SAMPLE_RATE, "PCM_24")

fad_score = frechet.score("background", "test1")
print("FAD score test 1: %.8f" % fad_score)

fad_score = frechet.score("background", "test2")
print("FAD score test 2: %.8f" % fad_score)

shutil.rmtree("background")
shutil.rmtree("test1")
shutil.rmtree("test2")
```

Results:
- Before this change, with numpy==1.23.5, scipy==1.11.1
```
FAD score test 1: -1.00000000
FAD score test 2: -1.00000000
```
- Before this change, numpy==1.23.4, scipy==1.10.1:
```
FAD score test 1: 11.65261423
FAD score test 2: 5.48465044
```
- After the change, numpy==1.23.5, scipy==1.11.3: 
```
FAD score test 1: 11.65261424
FAD score test 2: 5.48465045
```