### PR TITLE
add automatic MPS device support

### DIFF
--- a/frechet_audio_distance/fad.py
+++ b/frechet_audio_distance/fad.py
@@ -84,7 +84,6 @@ class FrechetAudioDistance:
         self.submodel_name = submodel_name
         self.sample_rate = sample_rate
         self.channels = channels
-        self.device = torch.device('cuda') if torch.cuda.is_available() else torch.device('cpu')
         self.verbose = verbose
         self.device = torch.device(
             'cuda') if torch.cuda.is_available() else torch.device('mps') if torch.backends.mps.is_available() else torch.device('cpu')


### PR DESCRIPTION
Add automatic GPU acceleration for arm-based Apple computers using the MPS device. It should behave the same way as automatic CUDA discovery on Nvidia GPUs.

If "cuda" device is not available, then query `torch.backends.mps.is_available()`, and only fall back to cpu if none of them are there.

Had to disable this for the CLAP models now, because:
`The operator 'aten::upsample_bicubic2d.out' is not currently implemented for the MPS device.`
It works with the rest.

Also moved the "Audio is mono..." warning in `get_embeddings` when using Encodec under a `self.verbose` check, otherwise it ends up being _very_ verbose in practice even if `self.verbose==False`. :)) Hope that's okay. 