### PR TITLE
Loosen Dependency Requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,4 +35,4 @@ dependencies = [
 "Homepage" = "https://github.com/gudgud96/frechet-audio-distance"
 
 [tool.setuptools]
-packages = ["frechet_audio_distance"]
+packages = ["frechet_audio_distance", "frechet_audio_distance.models"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,9 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-  'numpy==1.23.4',
+  'numpy>=1.23.4',
   'torch',
-  'scipy==1.10.1',
+  'scipy>=1.10.1',
   'tqdm',
   'soundfile',
   'resampy',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   'resampy',
   'torchlibrosa',
   'laion_clap',
-  'transformers<=4.30.2',
+  'transformers>=4.30.2',
   'torchaudio',
   'encodec',
 ]


### PR DESCRIPTION
Loosen Dependency Requirements on Numpy, Scipy and Transformer library.
Using a less strict requirement `>=` instead of `==` for library version.

Added "frechet_audio_distance.models" on line 38, to fix missing "models" folder after installing the repo.